### PR TITLE
fix: list-all prints versions when running under asdf

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,4 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions
+list_all_versions | xargs echo


### PR DESCRIPTION
My fault for only testing with [mise](https://mise.jdx.dev/).
