### PR TITLE
fix: improve error handling and version string parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v3
         with:
           plugin: nerves-toolchain
-          version: 13.2.0-aarch64-nerves-linux-gnu
+          version: v13.2.0-aarch64-nerves-linux-gnu
           command: aarch64-nerves-linux-gnu-gcc --version

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ nerves-toolchain:
 asdf list-all nerves-toolchain
 
 # Install specific version
-asdf install nerves-toolchain 13.2.0-aarch64-nerves-linux-gnu
+asdf install nerves-toolchain v13.2.0-aarch64-nerves-linux-gnu
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global nerves-toolchain 13.2.0-aarch64-nerves-linux-gnu
+asdf global nerves-toolchain v13.2.0-aarch64-nerves-linux-gnu
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to


### PR DESCRIPTION
* Handle the presence (or lack) of a leading `v` in the version string
  passed to the download/install scripts
* Improve error messages when GitHub API token is invalid (401) or API
  rate limit has been exceeded (403)
